### PR TITLE
[DO NOT MERGE] Bundle "sherlock-plugin" into the Sherlock platform.

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/plugins/sherlock-plugin/com.google.sherlockPlugin.iml" filepath="$PROJECT_DIR$/plugins/sherlock-plugin/com.google.sherlockPlugin.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/feature-usage-database/plugin-community/intellij.ae.database.community.iml" filepath="$PROJECT_DIR$/plugins/feature-usage-database/plugin-community/intellij.ae.database.community.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/feature-usage-database/core/intellij.ae.database.core.iml" filepath="$PROJECT_DIR$/plugins/feature-usage-database/core/intellij.ae.database.core.iml" />
       <module fileurl="file://$PROJECT_DIR$/plugins/feature-usage-database/counters/intellij.ae.database.counters.community.iml" filepath="$PROJECT_DIR$/plugins/feature-usage-database/counters/intellij.ae.database.counters.community.iml" />

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
@@ -22,6 +22,12 @@ import kotlinx.collections.immutable.persistentListOf
  * See also: BaseIdeaProperties, IdeaCommunityProperties.
  */
 class SherlockProperties(home: Path) : BaseIdeaProperties() {
+    companion object {
+      private val EXTRA_PLUGINS = listOf(
+        "com.google.sherlockPlugin",
+      )
+    }
+
     init {
       platformPrefix = "SherlockPlatform"
       applicationInfoModule = "intellij.idea.community.customization" // TODO: better to use own module.
@@ -32,9 +38,11 @@ class SherlockProperties(home: Path) : BaseIdeaProperties() {
         "intellij.platform.starter",
         "intellij.idea.community.customization",
       )
-      // TODO: Bundle plugin here
-      productLayout.bundledPluginModules = mutableListOf()
+
+      val bundledPlugins =  EXTRA_PLUGINS
+      productLayout.bundledPluginModules = bundledPlugins.toMutableList()
       productLayout.pluginLayouts = persistentListOf()
+      productLayout.buildAllCompatiblePlugins = true
     }
 
     override val baseFileName: String = "sherlock-platform"

--- a/plugins/sherlock-plugin/.gitignore
+++ b/plugins/sherlock-plugin/.gitignore
@@ -1,0 +1,42 @@
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/vcs.xml
+.idea/workspace.xml
+.idea/libraries/
+*.iws
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+.intellijPlatform/self-update.lock
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/plugins/sherlock-plugin/.idea/.gitignore
+++ b/plugins/sherlock-plugin/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/plugins/sherlock-plugin/.idea/copyright/Google.xml
+++ b/plugins/sherlock-plugin/.idea/copyright/Google.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright &amp;#36;today.year Google LLC&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;     http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+    <option name="myName" value="Google" />
+  </copyright>
+</component>

--- a/plugins/sherlock-plugin/.idea/copyright/profiles_settings.xml
+++ b/plugins/sherlock-plugin/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Google" />
+</component>

--- a/plugins/sherlock-plugin/README.md
+++ b/plugins/sherlock-plugin/README.md
@@ -1,0 +1,6 @@
+# Sherlock Plugin for IntelliJ
+
+This directory contains an IntelliJ plugin for the GPU profiler.
+
+To learn about how to build IntelliJ plugins, see the 
+[IntelliJ Platform SDK documentation](https://plugins.jetbrains.com/docs/intellij/welcome.html).

--- a/plugins/sherlock-plugin/com.google.sherlockPlugin.iml
+++ b/plugins/sherlock-plugin/com.google.sherlockPlugin.iml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module relativePaths="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$/">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/proto/main/java" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/proto/main/grpc" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/proto" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/build/extracted-protos/main" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/extracted-include-protos/main" isTestSource="false" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/source/proto/test/java" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/proto" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/extracted-protos/test" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/build/extracted-include-protos/test" isTestSource="true" generated="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/.intellijPlatform" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Gradle" level="project" />
+    <orderEntry type="library" name="kotlin-stdlib" level="project" />
+    <orderEntry type="module" module-name="intellij.platform.core" />
+    <orderEntry type="module" module-name="intellij.platform.editor" />
+    <orderEntry type="module" module-name="intellij.python.community.impl" />
+    <orderEntry type="module" module-name="intellij.platform.util.ui" />
+    <orderEntry type="module" module-name="intellij.platform.ide" />
+    <orderEntry type="library" name="protobuf" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="JUnit5" level="project" />
+    <orderEntry type="library" exported="" scope="TEST" name="JUnit4" level="project" />
+    <orderEntry type="module" module-name="intellij.platform.testFramework" scope="TEST" />
+  </component>
+</module>

--- a/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/editor/PerfettoFileEditor.kt
+++ b/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/editor/PerfettoFileEditor.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.editor
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.annotations.Nls
+import java.awt.BorderLayout
+import java.beans.PropertyChangeListener
+import java.nio.file.Path
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+/**
+ * Customizes the display of Perfetto trace file content within an IDE editor tab.
+ *
+ * While currently showing a placeholder, this `FileEditor` is designed to eventually provide a specialized interface
+ * for visualizing and interacting with the performance data captured in Perfetto traces.
+ */
+class PerfettoFileEditor(private val file: VirtualFile) : FileEditor {
+
+    private var panel: JPanel? = null
+
+    override fun getFile(): VirtualFile {
+        return file
+    }
+
+    override fun getComponent(): JComponent {
+        ApplicationManager.getApplication().assertIsDispatchThread()
+        if (panel == null) {
+            panel = PlaceholderPanel()
+        }
+        return panel as JPanel
+    }
+
+    @Nls(capitalization = Nls.Capitalization.Title)
+    override fun getName(): String {
+        return file.name
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent? {
+        return null
+    }
+
+    override fun isModified(): Boolean {
+        return false
+    }
+
+    override fun isValid(): Boolean {
+        return true
+    }
+
+    override fun setState(p0: FileEditorState) {}
+
+
+    override fun <T : Any?> getUserData(p0: Key<T>): T? {
+        return null
+    }
+
+    override fun <T : Any?> putUserData(p0: Key<T>, p1: T?) {}
+
+    override fun dispose() {}
+
+    override fun addPropertyChangeListener(p0: PropertyChangeListener) {}
+
+    override fun removePropertyChangeListener(p0: PropertyChangeListener) {}
+
+    companion object {
+        val LOG: Logger = Logger.getInstance(PerfettoFileEditor::class.java)
+    }
+
+    // TODO(ydbeis): Replace with LoadablePanel, which contains the trace view.
+    private class PlaceholderPanel : JPanel(BorderLayout()) {
+        init {
+            add(JLabel("This is a placeholder..."), BorderLayout.NORTH)
+
+            val pluginPath = PathManager.getPluginsPath()
+            val backend = Path.of(pluginPath, "sherlock/lib/main")
+            if (!backend.toFile().isFile()) {
+                LOG.error("Cannot find backend executable")
+            }
+        }
+    }
+}

--- a/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/editor/PerfettoFileEditorProvider.kt
+++ b/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/editor/PerfettoFileEditorProvider.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.editor
+
+import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.fileEditor.FileEditorPolicy
+import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.annotations.NonNls
+
+/**
+ * Registers the custom `PerfettoFileEditor` as the handler for Perfetto trace files, ensuring they are opened with the
+ * specialized visualization instead of the default editor.
+ */
+class PerfettoFileEditorProvider : FileEditorProvider, DumbAware {
+
+    // A collection of possible extensions for Perfetto-based trace files (aggregation of extensions used in
+    // Android Studio Profiler and Android Graphics Inspector).
+    private val PERFETTO_FILE_EXTENSIONS = listOf("perfetto", "trace", "pftrace", "perfetto-trace")
+
+    override fun accept(project: Project, file: VirtualFile): Boolean {
+        // Only handles files with specified Perfetto-indicating extensions.
+        return PERFETTO_FILE_EXTENSIONS.contains(file.extension)
+    }
+
+    override fun createEditor(project: Project, file: VirtualFile): FileEditor {
+        return PerfettoFileEditor(file)
+    }
+
+    override fun getPolicy(): FileEditorPolicy {
+        return FileEditorPolicy.HIDE_DEFAULT_EDITOR
+    }
+
+    override fun getEditorTypeId(): String {
+        return TYPE_ID
+    }
+
+    companion object {
+        @NonNls
+        private const val TYPE_ID = "perfetto"
+    }
+}

--- a/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/editor/PerfettoFileType.kt
+++ b/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/editor/PerfettoFileType.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.editor
+
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.util.NlsContexts
+import javax.swing.Icon
+
+/**
+ * Defines the file type for Perfetto trace files, providing metadata like name, description,and icon to be used in the
+ * IDE file view. Also specifies characteristics of the file type, like binary format and read-only behavior.
+ */
+class PerfettoFileType : FileType {
+
+    companion object {
+        // Used for "fieldName" in "plugin.xml".
+        @Suppress("UNUSED")
+        val INSTANCE = PerfettoFileType()
+
+        private const val DEFAULT_EXTENSION = "perfetto"
+        private const val FILE_TYPE_NAME = "Perfetto Trace File"
+        private const val FILE_TYPE_DESC = "Perfetto trace file"
+    }
+
+    override fun getName(): String {
+        return FILE_TYPE_NAME
+    }
+
+    @NlsContexts.Label
+    override fun getDescription(): String {
+        return FILE_TYPE_DESC
+    }
+
+    override fun getDefaultExtension(): String {
+        return DEFAULT_EXTENSION
+    }
+
+    override fun getIcon(): Icon {
+        // TODO(ydbeis): Replace with Perfetto-indicating icon.
+        return AllIcons.FileTypes.Any_type
+    }
+
+    override fun isBinary(): Boolean {
+        return true
+    }
+
+    override fun isReadOnly(): Boolean {
+        return true
+    }
+}

--- a/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/workflow/ConfigureRecordingAction.kt
+++ b/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/workflow/ConfigureRecordingAction.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.workflow
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+/**
+ * An action to show a dialog to let the user configure and start a recording.
+ */
+class ConfigureRecordingAction : AnAction() {
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project: Project? = e.project
+        StartRecordingDialog(project).show()
+    }
+}

--- a/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/workflow/StartRecordingDialog.kt
+++ b/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/workflow/StartRecordingDialog.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.workflow
+
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.project.Project
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import com.intellij.openapi.ui.ComboBox
+import com.intellij.ui.components.JBTabbedPane
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Show a dialog to let the user configure and start a recording.
+ */
+class StartRecordingDialog(val project: Project?): DialogWrapper(project) {
+
+    init {
+        super.init()
+        setTitle("Configure and Start a Recording")
+        setOKButtonText("Start Recording")
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val devicePane = JPanel(BorderLayout()).apply {
+            add(ComboBox<String>(arrayOf("No connected device")), BorderLayout.CENTER)
+            add(JButton("Refresh"), BorderLayout.EAST)
+        }
+        val configPane = JBTabbedPane().apply {
+            add("System Profiler", JPanel())
+            add("Frame Profiler", JPanel())
+        }
+        return JPanel(BorderLayout()).apply {
+            preferredSize = JBUI.size(400, 300)
+            add(devicePane, BorderLayout.NORTH)
+            add(configPane, BorderLayout.CENTER)
+        }
+    }
+
+    override fun doOKAction() {
+        super.doOKAction()
+        StopRecordingDialog(project).show()
+    }
+}

--- a/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/workflow/StopRecordingDialog.kt
+++ b/plugins/sherlock-plugin/src/main/java/com/google/sherlockPlugin/workflow/StopRecordingDialog.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.workflow
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.FlowLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+/**
+ * Show a dialog to confirm the recording is in progress and let the user stop it.
+ */
+class StopRecordingDialog(val project: Project?): DialogWrapper(project) {
+
+    init {
+        super.init()
+        setTitle("Recording in progress")
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val messageLabel = JLabel("Recording in progress...")
+        return JPanel(BorderLayout()).apply {
+            preferredSize = JBUI.size(300, 100)
+            add(messageLabel, BorderLayout.CENTER)
+        }
+    }
+
+    override fun createSouthPanel() =
+        JPanel(FlowLayout(FlowLayout.CENTER)).apply { add(JButton(okAction).apply { text = "Stop" }) }
+
+    override fun doOKAction() {
+        super.doOKAction()
+        // TODO(shukang): Start a thread to retrieve the trace and open it.
+    }
+
+
+}

--- a/plugins/sherlock-plugin/src/main/proto/path.proto
+++ b/plugins/sherlock-plugin/src/main/proto/path.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "com.google.gapid.proto.service.path";
+option java_outer_classname = "Path";
+
+package path;
+
+// Represents a capture file (e.g a Perfetto trace).
+// TODO(ydbeis): Populate with an ID field to identify the specific capture and other metadata fields.
+message Capture {}

--- a/plugins/sherlock-plugin/src/main/proto/perfetto.proto
+++ b/plugins/sherlock-plugin/src/main/proto/perfetto.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+option java_package = "com.google.gapid.proto.perfetto";
+option java_outer_classname = "Perfetto";
+
+package perfetto;
+
+// Represents the result of a Perfetto query structured as a table.
+message QueryResult {
+  // Describes a single column in the query result.
+  message ColumnDesc {
+    // The name of the column.
+    string name = 1;
+    // The data type of the column.
+    enum Type {
+      UNKNOWN = 0;
+      LONG = 1;
+      DOUBLE = 2;
+      STRING = 3;
+    }
+    Type type = 2;
+  }
+
+  // Contains the actual values for a single column, which can be a mix of different types (e.g. some long, some null).
+  message ColumnValues {
+    repeated int64 long_values = 1;
+    repeated double double_values = 2;
+    repeated string string_values = 3;
+    // Indicates which values are NULL (applicable to all column types).
+    repeated bool is_nulls = 4;
+  }
+
+  // Descriptors for each column in the result.
+  repeated ColumnDesc column_descriptors = 1;
+  // The total number of rows in the result.
+  uint64 num_records = 2;
+  // The actual values for each column, organized in the same order as column_descriptors.
+  // It is assumed that length(columns) == length(num_records).
+  repeated ColumnValues columns = 3;
+  // An error message, if the query execution failed.
+  string error = 4;
+}

--- a/plugins/sherlock-plugin/src/main/proto/service.proto
+++ b/plugins/sherlock-plugin/src/main/proto/service.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+import "path.proto";
+import "perfetto.proto";
+
+option java_package = "com.google.gapid.proto.service";
+option java_outer_classname = "Service";
+
+package service;
+
+// Service to load and query a capture file (e.g. a Perfetto trace).
+service Gapid {
+  // Loads a capture file into the service/backend for subsequent querying via the PerfettoQuery rpc.
+  rpc LoadCapture(LoadCaptureRequest) returns (LoadCaptureResponse) {}
+
+  // Executes a Perfetto query against a loaded capture.
+  rpc PerfettoQuery(PerfettoQueryRequest) returns (PerfettoQueryResponse) {}
+}
+
+// Request to load a capture file from the specified path.
+message LoadCaptureRequest {
+  // The path to the capture file.
+  string path = 1;
+}
+
+// Response to a LoadCaptureRequest.
+message LoadCaptureResponse {
+  oneof res {
+    // The loaded capture, if successful.
+    path.Capture capture = 1;
+    // An error message, if the load failed.
+    Error error = 2;
+  }
+}
+
+// A generic error message.
+// TODO(ydbeis): populate with useful error metadata.
+message Error {}
+
+// Request to execute a Perfetto query against a capture.
+message PerfettoQueryRequest {
+  // The capture to query.
+  path.Capture capture = 1;
+  // The Perfetto query to execute on the Capture, with the result being returned in PerfettoQueryResponse.
+  string query = 2;
+}
+
+// Response to a PerfettoQueryRequest.
+message PerfettoQueryResponse {
+  oneof res {
+    // The query result, if successful.
+    perfetto.QueryResult result = 1;
+    // An error message, if the query failed.
+    Error error = 2;
+  }
+}

--- a/plugins/sherlock-plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugins/sherlock-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,33 @@
+<!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
+<idea-plugin>
+    <!-- Unique identifier of the plugin. It should be FQN. It cannot be changed between the plugin versions. -->
+    <id>com.google.sherlock-plugin</id>
+
+    <!-- Public plugin name should be written in Title Case.
+         Guidelines: https://plugins.jetbrains.com/docs/marketplace/plugin-overview-page.html#plugin-name -->
+    <name>Sherlock</name>
+
+    <!-- Product and plugin compatibility requirements.
+         Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
+    <depends>com.intellij.modules.platform</depends>
+
+    <!-- Extension points defined by the plugin.
+         Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
+    <extensions defaultExtensionNs="com.intellij">
+        <fileType name="Perfetto Trace File"
+                  implementationClass="com.google.sherlockPlugin.editor.PerfettoFileType"
+                  fieldName="INSTANCE"
+                  extensions="perfetto;trace;pftrace;perfetto-trace"/>
+        <fileEditorProvider implementation="com.google.sherlockPlugin.editor.PerfettoFileEditorProvider"/>
+    </extensions>
+
+    <actions>
+        <action id="com.google.sherlock-plugin.ConfigureRecordingAction"
+                class="com.google.sherlockPlugin.workflow.ConfigureRecordingAction"
+                text="\\\\\ Sherlock /////"
+                description="Sherlock GPU Profiler">
+            <add-to-group group-id="FileMenu" anchor="first"/>
+        </action>
+
+    </actions>
+</idea-plugin>

--- a/plugins/sherlock-plugin/src/main/resources/META-INF/pluginIcon.svg
+++ b/plugins/sherlock-plugin/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,12 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M32.0845 7.94025V4H24.0203V7.9896H16.029V4H7.91553V7.94025H4V36H16.0044V32.0045C16.0058 30.9457 16.4274 29.9308 17.1766 29.1826C17.9258 28.4345 18.9412 28.0143 20 28.0143C21.0588 28.0143 22.0743 28.4345 22.8234 29.1826C23.5726 29.9308 23.9942 30.9457 23.9956 32.0045V36H36V7.94025H32.0845Z"
+          fill="url(#paint0_linear)"/>
+    <defs>
+        <linearGradient id="paint0_linear" x1="2.94192" y1="4.89955" x2="37.7772" y2="39.7345"
+                        gradientUnits="userSpaceOnUse">
+            <stop offset="0.15937" stop-color="#3BEA62"/>
+            <stop offset="0.5404" stop-color="#3C99CC"/>
+            <stop offset="0.93739" stop-color="#6B57FF"/>
+        </linearGradient>
+    </defs>
+</svg>

--- a/plugins/sherlock-plugin/src/test/java/com/google/sherlockPlugin/common/ExampleTest.kt
+++ b/plugins/sherlock-plugin/src/test/java/com/google/sherlockPlugin/common/ExampleTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.sherlockPlugin.common
+
+import com.intellij.openapi.application.PathManager
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.nio.file.Paths
+
+/**
+ * Demonstrates how to write simple IntelliJ unit tests.
+ */
+@RunWith(JUnit4::class)
+class ExampleTest : BasePlatformTestCase() {
+
+    @Test
+    fun `trace processor wrapper file exists in sandbox`() {
+        val path = Paths.get(PathManager.getPluginsPath(), "sherlock", "lib", "main")
+        assertExists(path.toFile())
+
+    }
+}


### PR DESCRIPTION
(Fixes #26) This change modifies the `sherlock platform` so that it builds and runs the `sherlock-plugin` when getting launched. This will ensure that we can release a prebuilt tool that is bundled with the `sherlock-plugin `on top of a customised Intellij platform. 

For now, I have modified and added the plugin into the platform's codebase to make this tool usable and reproducible for reviewing and modification purposes.  I'll design how the plugin's codebase should be along side the platform's whilst ensuring convenience of the developers. 

To see the change in action follow these - 

1. `./build_sherlock_platform.sh`
2. extract  `out/sherlock-platform/artifacts ` according to OS.
3. Launch  `out/sherlock-platform/artifacts/sherlock-platform-242.21829/Sherlock Platform-2024.2.1/bin/sherlock-platform`
4. 
![Screenshot from 2024-10-22 15-14-34](https://github.com/user-attachments/assets/f9ba79e7-f0f9-4980-b400-08e85c29420b)

