### PR TITLE
Setup GitHub actions to build IntelliJ Platform.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build Sherlock Platform
+
+on:
+  # Triggers the workflow on push or pull request events but only for the idea/242.21829.142 branch
+  #push:
+  #  branches: [ idea/242.21829.142 ]
+  #pull_request:
+  #  branches: [ idea/242.21829.142 ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set JAVA_HOME
+        run: echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+
+      - name: Grant execute permission to build script
+        run: chmod +x ./build_sherlock_platform.sh
+
+      - name: Build Sherlock Platform
+        run: ./build_sherlock_platform.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sherlock-platform
+          path: out/sherlock-platform/artifacts/sherlock-platform-242.21829.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,13 @@ name: Build Sherlock Platform
 
 on:
   # Triggers the workflow on push or pull request events but only for the idea/242.21829.142 branch
-  #push:
-  #  branches: [ idea/242.21829.142 ]
-  #pull_request:
-  #  branches: [ idea/242.21829.142 ]
+  # TODO: Update the branch once finalised
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -33,8 +36,26 @@ jobs:
       - name: Build Sherlock Platform
         run: ./build_sherlock_platform.sh
 
-      - name: Upload artifact
+      - name: Upload Sherlock Platform artifact for Linux
         uses: actions/upload-artifact@v3
         with:
-          name: sherlock-platform
-          path: out/sherlock-platform/artifacts/sherlock-platform-242.21829.tar.gz
+          name: sherlock-platform-linux
+          path: out/sherlock-platform/artifacts/sherlock-platform.tar.gz
+
+      - name: Upload Sherlock Platform artifact for Mac
+        uses: actions/upload-artifact@v3
+        with:
+          name: sherlock-platform-mac
+          path: out/sherlock-platform/artifacts/sherlock-platform.mac.aarch64.zip
+
+      - name: Upload Sherlock Platform artifact for Windows
+        uses: actions/upload-artifact@v3
+        with:
+          name: sherlock-platform-win
+          path: out/sherlock-platform/artifacts/sherlock-platform.win.zip
+
+      - name: Upload Sherlock Platform Sources
+        uses: actions/upload-artifact@v3
+        with:
+          name: sherlock-platform-sources
+          path: out/sherlock-platform/artifacts/sherlock-platform-sources.zip

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
@@ -40,7 +40,7 @@ class SherlockProperties(home: Path) : BaseIdeaProperties() {
 
     override val baseFileName: String = "sherlock-platform"
 
-    override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform-$buildNumber"
+    override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform"
 
     override fun getSystemSelector(appInfo: ApplicationInfoProperties, buildNumber: String): String = "SherlockPlatform"
 


### PR DESCRIPTION
This change adds a GitHub Actions workflow to automate the build process for the Sherlock Platform (Fixes #13)  

1. Automatically builds the Sherlock Platform whenever changes are pushed to the `idea/242.21829.142` branch or a pull request is created. 
2. The workflow sets up JDK 17 and configures the JAVA_HOME environment variable
3. Builds the platform using the `build_sherlock_platform.sh` script and generates artifact for Linux, Mac and Windows. (Have also modified ` SherlockProperties.kt` to update the name of the artifact generated. )
4. The generated artifact - `sherlock-platform` as well as `sherlock-platform-sources`  are automatically uploaded as a downloadable artifact in the workflow run, 
