### PR TITLE
Cache maven artifacts used by IntelliJ build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v3.0.2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('build.txt') }}
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
The first step in the platform build is to download the Maven artifacts required by the build. This takes 3-4 minutes on the GitHub runners, and it's about 700-800MB in size. Using a GitHub cache that's indexed by the build.txt contents, we can reduce this down to ~10 seconds.  