### PR TITLE
Fix triggering of release.yml on releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,7 @@ name: Release Sherlock Platform prebuilt
 
 on:
   release:
-    types:
-      - created
-      - edited
-      - prereleased
-      - published
-      - released
+    types: [created, edited, published, prereleased, released]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,13 @@
 name: Release Sherlock Platform prebuilt
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - created
+      - edited
+      - prereleased
+      - published
+      - released
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The previous event of `push` wasn't triggering when releases were created manually using the Github UI. This should trigger it wheever a new release is created, edited, prereleased etc.