### PR TITLE
Updated cache version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Cache local Maven repository
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('build.txt') }}


### PR DESCRIPTION
Previous cache version in actions is deprecated as per - https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down 