### PR TITLE
Fixed the file detection for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            sherlock-platform-artifacts/*
+            sherlock-platform-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            sherlock-platform-*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            sherlock-platform-artifacts/*/*


### PR DESCRIPTION
The current workflow was not able to detect the downloaded artifacts because according to the github docs- 

> If the name input parameter is not provided, all artifacts will be downloaded. To differentiate between downloaded artifacts, a directory denoted by the artifacts name will be created for each individual artifact.

This change (finally!) fixes the detection of those files now. You can refer the [run](https://github.com/sonakshisaxena1/sherlock-platform/actions/runs/12779887287) on my repo that was able to successfully find and release the artifact. 