### PR TITLE
Drop 'Platform' from the name of the product

### DIFF
--- a/sherlock-branding/resources/idea/SherlockPlatformApplicationInfo.xml
+++ b/sherlock-branding/resources/idea/SherlockPlatformApplicationInfo.xml
@@ -5,5 +5,5 @@
   <logo url="/idea_community_logo.png"/><!-- TODO -->
   <icon svg="/idea-ce.svg" svg-small="/idea-ce_16.svg"/><!-- TODO -->
   <icon-eap svg="/idea-ce-eap.svg" svg-small="/idea-ce-eap_16.svg"/><!-- TODO -->
-  <names product="SherlockPlatform" fullname="Sherlock Platform" script="platform" motto="Customised IntelliJ Platform for Sherlock"/>
+  <names product="Sherlock" fullname="Sherlock" script="platform" motto="IntelliJ Platform for Sherlock"/>
 </component>


### PR DESCRIPTION
This is used as the name of the product in the main IDE UI, so it should be 'Sherlock' instead of 'Sherlock Platform'.