### PR TITLE
Enable version change after generating a distributable.

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
@@ -33,7 +33,6 @@ class SherlockProperties(home: Path) : BaseIdeaProperties() {
         "intellij.platform.starter",
         "com.google.sherlock.branding",
       )
-      // TODO: Bundle plugin here
       productLayout.bundledPluginModules = mutableListOf()
       productLayout.pluginLayouts = persistentListOf()
     }


### PR DESCRIPTION
This change does the following:
1. Code change in the Intellij platform code to enable version change after the distributable has been generated. Fixes #65 
2. Removes a `#TODO` from `SherlockProperties.kt` as it unnecessary and a trivial change. 


Tests: Manually confirmed modification of version after including this patch.

Note to the reviewer: This is similar to a change made in Studio in '23 - [ag/25533406](https://ag.corp.google.com/25533406)

