### PR TITLE
Enable version change after generating a distributable.

### DIFF
--- a/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/SherlockProperties.kt
@@ -14,6 +14,7 @@
  ***/
 
 package org.jetbrains.intellij.build
+
 import java.nio.file.Path
 import kotlinx.collections.immutable.persistentListOf
 
@@ -22,46 +23,45 @@ import kotlinx.collections.immutable.persistentListOf
  * See also: BaseIdeaProperties, IdeaCommunityProperties.
  */
 class SherlockProperties(home: Path) : BaseIdeaProperties() {
-    init {
-      platformPrefix = "SherlockPlatform"
-      applicationInfoModule = "com.google.sherlock.branding"
-      useSplash = true
-      buildSourcesArchive = true
-      productLayout.buildAllCompatiblePlugins = false
-      productLayout.prepareCustomPluginRepositoryForPublishedPlugins = false
-      productLayout.productImplementationModules = listOf(
-        "intellij.platform.starter",
-        "com.google.sherlock.branding",
-      )
-      // TODO: Bundle plugin here
-      productLayout.bundledPluginModules = mutableListOf()
-      productLayout.pluginLayouts = persistentListOf()
-    }
+  init {
+    platformPrefix = "SherlockPlatform"
+    applicationInfoModule = "com.google.sherlock.branding"
+    useSplash = true
+    buildSourcesArchive = true
+    productLayout.buildAllCompatiblePlugins = false
+    productLayout.prepareCustomPluginRepositoryForPublishedPlugins = false
+    productLayout.productImplementationModules = listOf(
+      "intellij.platform.starter",
+      "com.google.sherlock.branding",
+    )
+    productLayout.bundledPluginModules = mutableListOf()
+    productLayout.pluginLayouts = persistentListOf()
+  }
 
-    override val baseFileName: String = "sherlock"
+  override val baseFileName: String = "sherlock"
 
-    override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform"
+  override fun getBaseArtifactName(appInfo: ApplicationInfoProperties, buildNumber: String): String = "sherlock-platform"
 
-    override fun getSystemSelector(appInfo: ApplicationInfoProperties, buildNumber: String): String = "SherlockPlatform"
+  override fun getSystemSelector(appInfo: ApplicationInfoProperties, buildNumber: String): String = "SherlockPlatform"
 
-    override fun createLinuxCustomizer(projectHome: String): LinuxDistributionCustomizer {
-      return object : LinuxDistributionCustomizer() {}
-    }
+  override fun createLinuxCustomizer(projectHome: String): LinuxDistributionCustomizer {
+    return object : LinuxDistributionCustomizer() {}
+  }
 
-    override fun createMacCustomizer(projectHome: String): MacDistributionCustomizer {
-      return object : MacDistributionCustomizer() {
-        init {
-          bundleIdentifier = "com.google.sherlock.platform"
-          icnsPath = "${projectHome}/build/conf/ideaCE/mac/images/idea.icns" // TODO
-        }
+  override fun createMacCustomizer(projectHome: String): MacDistributionCustomizer {
+    return object : MacDistributionCustomizer() {
+      init {
+        bundleIdentifier = "com.google.sherlock.platform"
+        icnsPath = "${projectHome}/build/conf/ideaCE/mac/images/idea.icns" // TODO
       }
     }
+  }
 
-    override fun createWindowsCustomizer(projectHome: String): WindowsDistributionCustomizer {
-      return object : WindowsDistributionCustomizer() {
-        init {
-          icoPath = "${projectHome}/build/conf/ideaCE/win/images/idea_CE.ico" // TODO
-        }
+  override fun createWindowsCustomizer(projectHome: String): WindowsDistributionCustomizer {
+    return object : WindowsDistributionCustomizer() {
+      init {
+        icoPath = "${projectHome}/build/conf/ideaCE/win/images/idea_CE.ico" // TODO
       }
     }
+  }
 }

--- a/platform/build-scripts/src/org/jetbrains/intellij/build/impl/DistributionJARsBuilder.kt
+++ b/platform/build-scripts/src/org/jetbrains/intellij/build/impl/DistributionJARsBuilder.kt
@@ -754,6 +754,7 @@ suspend fun layoutPlatformDistribution(
       launch {
         patchKeyMapWithAltClickReassignedToMultipleCarets(moduleOutputPatcher = moduleOutputPatcher, context = context)
       }
+      /* Sherlock: ApplicationNamesInfo shouldn't be patched to enable version modifications later.
       launch {
         spanBuilder("write patched app info").use {
           val moduleOutDir = context.getModuleOutputDir(context.findRequiredModule("intellij.platform.core"))
@@ -762,6 +763,7 @@ suspend fun layoutPlatformDistribution(
           moduleOutputPatcher.patchModuleOutput("intellij.platform.core", relativePath, result)
         }
       }
+      */
     }
   }
 


### PR DESCRIPTION
This change does the following:

- Code change in the Intellij platform code to enable version change after the distributable has been generated. Fixes https://github.com/android-graphics/sherlock-platform/issues/65
- Removed a #TODO from SherlockProperties.kt as it unnecessary and a trivial change. 
- Reformatted `SherlockProperties.kt` file after the above change to be consistent with our coding style.

Tests: Manually confirmed modification of version after including this patch.

Note to the reviewer: This is similar to a change made in Studio in '23 - [ag/25533406](https://ag.corp.google.com/25533406)