### PR TITLE
Run workflows only on `created` events

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release Sherlock Platform prebuilt
 
 on:
   release:
-    types: [created, edited, published, prereleased, released]
+    types: [created]
   workflow_dispatch:
     inputs:
       release_tag:


### PR DESCRIPTION
When we create a release, it was starting the same workflow multiple times due to [prereleased, created, published] events all triggering simultaneously:

https://screenshot.googleplex.com/3PGL5usPimTTTEw