### PR TITLE
Make Sherlock Platform version stay in sync with the release

### DIFF
--- a/sherlock-branding/resources/idea/SherlockPlatformApplicationInfo.xml
+++ b/sherlock-branding/resources/idea/SherlockPlatformApplicationInfo.xml
@@ -1,5 +1,5 @@
 <component xmlns="http://jetbrains.org/intellij/schema/application-info">
-  <version major="2024" minor="2.1"/>
+  <version major="1" minor="0" patch="0"/>
   <company name="Google" url="http://developer.android.com"/>
   <build number="IC-__BUILD__" date="__BUILD_DATE__" majorReleaseDate="20240806" />
   <logo url="/idea_community_logo.png"/><!-- TODO -->


### PR DESCRIPTION
We should ensure that the version visible when platform is launched matches the latest prerelease version. (Perhaps as a rule, we should update this first prior to creating a new prerelease).
The `SherlockPlatformApplicationInfo.xml` only  allows positive numbers under the version's major, so let's update the prelease to v1.0.0 once this gets merged. Same goes to the PR [here](https://github.com/android-graphics/sherlock/pull/427)  in Sherlock