### PR TITLE
Fix release.yml xml path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Get SherlockPlatformApplicationInfo.xml Version
         id: get_xml_version
         run: |
-          XML_VERSION=$(python ../scripts/get_version.py)
+          XML_VERSION=$(python .github/scripts/get_version.py)
           echo "xml_version=$XML_VERSION" >> $GITHUB_OUTPUT
 
       - name: Download Artifacts from Build Workflow


### PR DESCRIPTION
[Release for v1.0.0](https://github.com/android-graphics/sherlock-platform/actions/runs/14066409068) failed as the path in `release.yml `is relative to the workflow but the workflow expects the path relative to the root.