### PR TITLE
Remove run, debug and run configuration widget

### DIFF
--- a/platform/platform-resources/src/idea/LangActions.xml
+++ b/platform/platform-resources/src/idea/LangActions.xml
@@ -1655,10 +1655,10 @@
       </group>
     </group>
 
-
-    <action id="NewUiRunWidget" class="com.intellij.execution.ui.RedesignedRunToolbarWrapper">
-      <add-to-group group-id="MainToolbarRight" anchor="first"/>
-    </action>
+    <!--Sherlock doesn't support Run and Debug-->
+    <!--<action id="NewUiRunWidget" class="com.intellij.execution.ui.RedesignedRunToolbarWrapper">-->
+    <!--  <add-to-group group-id="MainToolbarRight" anchor="first"/>-->
+    <!--</action>-->
 
     <group id="RunToolbarMainActionGroup">
       <action class="com.intellij.execution.ui.RedesignedRunConfigurationSelector" id="RedesignedRunConfigurationSelector"/>

--- a/platform/platform-resources/src/idea/LangActions.xml
+++ b/platform/platform-resources/src/idea/LangActions.xml
@@ -1655,9 +1655,10 @@
       </group>
     </group>
 
-    <!--Sherlock: Remove Run and Debug widget-->
     <action id="NewUiRunWidget" class="com.intellij.execution.ui.RedesignedRunToolbarWrapper">
-      <!--<add-to-group group-id="MainToolbarRight" anchor="first"/>-->
+      <!--Sherlock: Remove Run and Debug widget
+      <add-to-group group-id="MainToolbarRight" anchor="first"/>
+      -->
     </action>
 
     <group id="RunToolbarMainActionGroup">

--- a/platform/platform-resources/src/idea/LangActions.xml
+++ b/platform/platform-resources/src/idea/LangActions.xml
@@ -1655,10 +1655,10 @@
       </group>
     </group>
 
-    <!--Sherlock doesn't support Run and Debug-->
-    <!--<action id="NewUiRunWidget" class="com.intellij.execution.ui.RedesignedRunToolbarWrapper">-->
-    <!--  <add-to-group group-id="MainToolbarRight" anchor="first"/>-->
-    <!--</action>-->
+    <!--Sherlock: Remove Run and Debug widget-->
+    <action id="NewUiRunWidget" class="com.intellij.execution.ui.RedesignedRunToolbarWrapper">
+      <!--<add-to-group group-id="MainToolbarRight" anchor="first"/>-->
+    </action>
 
     <group id="RunToolbarMainActionGroup">
       <action class="com.intellij.execution.ui.RedesignedRunConfigurationSelector" id="RedesignedRunConfigurationSelector"/>


### PR DESCRIPTION
Before 
<img width="1280" alt="Screenshot 2025-04-30 at 17 44 55" src="https://github.com/user-attachments/assets/61d6a2a6-d59b-4ba6-9961-9f3afb4f278f" />

After
<img width="1280" alt="Screenshot 2025-04-30 at 17 44 29" src="https://github.com/user-attachments/assets/cb465c22-b8ab-4e52-b630-449af0cd69bc" />


Fixes #88 