### PR TITLE
Defined an extension contract for new capture flow

### DIFF
--- a/sherlock-platform/customization/resources/META-INF/SherlockPlatformCustomization.xml
+++ b/sherlock-platform/customization/resources/META-INF/SherlockPlatformCustomization.xml
@@ -19,6 +19,12 @@
       <!--Include statistics.counterUsagesCollector for recording user or IDE actions.-->
     </extensions>
 
+    <extensionPoints>
+      <extensionPoint qualifiedName="com.google.sherlock.customization.newCapturePerformer"
+                      interface="com.google.sherlock.newCapture.NewCapturePerformer"
+                      dynamic="true"/>
+    </extensionPoints>
+
     <actions resource-bundle="messages.ActionsBundle">
 
       <group id="PlatformOpenProjectGroup">

--- a/sherlock-platform/customization/src/com/google/sherlock/newCapture/NewCapturePerformer.kt
+++ b/sherlock-platform/customization/src/com/google/sherlock/newCapture/NewCapturePerformer.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Google LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.sherlock.newCapture
+
+import com.intellij.openapi.project.Project
+
+/**
+ * Defines the contract for performing a new capture operation.
+ * Plugins wishing to provide capture functionality for the "New Capture" action
+ * must implement this interface.
+ */
+interface NewCapturePerformer {
+  /**
+   * Called when the "New Capture" action is invoked and this performer is selected.
+   *
+   * @param project The current project context.
+   */
+  fun performCapture(project: Project)
+}


### PR DESCRIPTION
This will be used by sherlock plugin to implement the new capture functionality when the "New Capture" button is clicked. 

This is what happens when the use clicks on the "New Capture" button without any implementation. 


<img width="442" alt="Screenshot 2025-05-07 at 2 16 35 pm" src="https://github.com/user-attachments/assets/38bab323-6e24-46d6-a455-0f85f4acd2dd" />



Fixes #92 