### PR TITLE
Remove language and region support

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/CustomizeTabFactory.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/CustomizeTabFactory.kt
@@ -260,8 +260,10 @@ private class CustomizeTab(val parentDisposable: Disposable) : DefaultWelcomeScr
         }
       }
 
+      /** Sherlock: Remove Language and Region Support
       header(IdeBundle.message("title.language.and.region"))
       LanguageAndRegionUi.createContent(this, propertyGraph, parentDisposable, lafConnection, EventSource.WELCOME_SCREEN)
+      **/
 
       header(IdeBundle.message("title.accessibility"))
 

--- a/platform/platform-resources/src/META-INF/PlatformExtensions.xml
+++ b/platform/platform-resources/src/META-INF/PlatformExtensions.xml
@@ -720,9 +720,11 @@
                              key="configurable.CertificateConfigurable.display.name"
                              id="http.certificates" instance="com.intellij.util.net.ssl.CertificateConfigurable"/>
 
+    <!--Sherlock: Remove Language and Region Support
     <applicationConfigurable parentId="preferences.general" instance="com.intellij.ide.ui.LanguageAndRegionConfigurable"
                              id="preferences.language.and.region"
                              key="title.language.and.region" bundle="messages.IdeBundle"/>
+    -->
 
     <fileType name="ARCHIVE" implementationClass="com.intellij.ide.highlighter.ArchiveFileType" fieldName="INSTANCE"
               extensions="ane;apk;ear;egg;jar;swc;war;zip"/>


### PR DESCRIPTION
Remove it from the "Welcome Page > Customize" as well as "Setttings > Language and Region"


**1. Welcome Page:**

_Before:_
<img width="912" alt="Screenshot 2025-05-12 at 14 32 38" src="https://github.com/user-attachments/assets/eb2387a9-78cf-4fd1-84ee-ab8229bbc508" />


_After:_

<img width="1439" alt="Screenshot 2025-05-12 at 14 55 27" src="https://github.com/user-attachments/assets/52eb32f6-e8dc-4653-a22d-85e82a8ef8fb" />



**2. Settings Page:**


_Before:_
<img width="994" alt="Screenshot 2025-05-12 at 15 01 58" src="https://github.com/user-attachments/assets/9351847f-d13f-4378-80a3-370a4c840275" />


_After:_

<img width="997" alt="Screenshot 2025-05-12 at 14 54 46" src="https://github.com/user-attachments/assets/72a16eb5-9dd4-4a8e-885d-8f6a5c6f9081" />



Fixes #99 