### PR TITLE
Remove accessibility support from welcome page

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/ui/AppearanceConfigurable.kt
+++ b/platform/platform-impl/src/com/intellij/ide/ui/AppearanceConfigurable.kt
@@ -237,6 +237,7 @@ internal class AppearanceConfigurable : BoundSearchableConfigurable(message("tit
         }
       }
 
+      /** Sherlock: Remove Accessibility support
       group(message("title.accessibility")) {
         row(message("combobox.ide.scale.percent")) {
           val defaultScale = UISettingsUtils.defaultScale(false)
@@ -379,6 +380,7 @@ internal class AppearanceConfigurable : BoundSearchableConfigurable(message("tit
           }
         }
       }
+      **/
 
       groupRowsRange(message("group.ui.options")) {
         val leftColumnControls = sequence<Row.() -> Unit> {

--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/CustomizeTabFactory.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/CustomizeTabFactory.kt
@@ -263,6 +263,7 @@ private class CustomizeTab(val parentDisposable: Disposable) : DefaultWelcomeScr
       header(IdeBundle.message("title.language.and.region"))
       LanguageAndRegionUi.createContent(this, propertyGraph, parentDisposable, lafConnection, EventSource.WELCOME_SCREEN)
 
+      /** Sherlock: Remove Accessibility Support
       header(IdeBundle.message("title.accessibility"))
 
       row(IdeBundle.message("welcome.screen.ide.font.size.label")) {
@@ -270,6 +271,7 @@ private class CustomizeTab(val parentDisposable: Disposable) : DefaultWelcomeScr
       }.bottomGap(BottomGap.SMALL)
 
       createColorBlindnessSettingBlock()
+      **/
 
       header(KeyMapBundle.message("keymap.display.name"))
       row {


### PR DESCRIPTION
**Welcome > Customize**

_Before:_
<img width="912" alt="Screenshot 2025-05-12 at 14 32 38" src="https://github.com/user-attachments/assets/8e4da305-e092-4aad-8923-c02440c28c55" />



_After:_
<img width="1435" alt="Screenshot 2025-05-12 at 15 06 36" src="https://github.com/user-attachments/assets/5eebde9f-7458-4a06-aad5-9acf940149cb" />


**Settings > Appearance:**

_Before_
<img width="1467" alt="Screenshot 2025-05-12 at 15 35 14" src="https://github.com/user-attachments/assets/41963a2b-826c-4534-bbae-bae9222c9a53" />


_After_
<img width="997" alt="Screenshot 2025-05-12 at 15 34 54" src="https://github.com/user-attachments/assets/2e517da8-d410-4648-b117-40f11c05a89c" />


Fixes #100 