### PR TITLE
Remove run from settings drop-down

### DIFF
--- a/platform/platform-resources/src/idea/PlatformActions.xml
+++ b/platform/platform-resources/src/idea/PlatformActions.xml
@@ -1633,8 +1633,10 @@
 
     <group id="UpdateEntryPointGroup"/>
     <group id="SettingsEntryPointGroup" class="com.intellij.ide.actions.SettingsEntryPointGroup">
+      <!--Sherlock: Remove Run option
       <reference id="RunAnything"/>
       <separator/>
+      -->
       <reference id="ShowSettings"/>
       <reference id="WelcomeScreen.Plugins"/>
       <separator/>


### PR DESCRIPTION
This got missed when we were removing "Run/Debug/Build" etc from #89 #90 

Before: 
<img width="263" alt="Screenshot 2025-05-13 at 16 14 32" src="https://github.com/user-attachments/assets/520c535f-cd8f-47b9-9dff-36ccc0f874a4" />

After: 
<img width="239" alt="Screenshot 2025-05-13 at 16 19 46" src="https://github.com/user-attachments/assets/61f8abff-6e6c-42b9-a02c-e60bc3f87217" />





Fixes #103 