### PR TITLE
Removes theme/appearance option from Welcome > Customize page

### DIFF
--- a/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/CustomizeTabFactory.kt
+++ b/platform/platform-impl/src/com/intellij/openapi/wm/impl/welcomeScreen/CustomizeTabFactory.kt
@@ -198,7 +198,11 @@ private class CustomizeTab(val parentDisposable: Disposable) : DefaultWelcomeScr
       val syncThemeAndEditorSchemePredicate = autodetectSupportedPredicate.and(
         ComponentPredicate.fromObservableProperty(syncThemeProperty, parentDisposable))
 
+      /** Sherlock: All appearance settings have been removed
       header(IdeBundle.message("welcome.screen.color.theme.header"), true)
+      **/
+
+      /** Sherlock: Only supports "Light" theme
       row(IdeBundle.message("combobox.look.and.feel")) {
         val themeBuilder = comboBox(LafComboBoxModelWrapper { laf.lafComboBoxModel })
           .bindItem(lafProperty)
@@ -259,6 +263,7 @@ private class CustomizeTab(val parentDisposable: Disposable) : DefaultWelcomeScr
           colorAndFontsOptions.disposeUIResources()
         }
       }
+      **/
 
       /** Sherlock: Remove Language and Region Support
       header(IdeBundle.message("title.language.and.region"))


### PR DESCRIPTION
Sherlock doesn't support dark theme or any other themes so we are making light theme as default. This PR removes the option to change theme on the welcome page. It will be followed by PR #110  that sets "light theme" as default.


Before: 

<img width="955" alt="Screenshot 2025-05-13 at 17 13 32" src="https://github.com/user-attachments/assets/93da3552-9936-4cb4-967f-a72244f1ccec" />

After:

<img width="960" alt="Screenshot 2025-05-13 at 17 10 04" src="https://github.com/user-attachments/assets/c6a8c5bc-6690-4ebe-9462-bd51a6a3a61c" />

Fixes #106 
