### PR TITLE
Makes "light" theme as default theme for sherlock

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/ui/laf/LafManagerImpl.kt
+++ b/platform/platform-impl/src/com/intellij/ide/ui/laf/LafManagerImpl.kt
@@ -509,7 +509,10 @@ class LafManagerImpl(private val coroutineScope: CoroutineScope) : LafManager(),
         return it
       }
     }
+    /** Sherlock: Make "Light" theme as default
     return Supplier { defaultDarkLaf }
+    **/
+    return Supplier { defaultLightLaf }
   }
 
   private fun getDefaultThemeId(): String {
@@ -519,7 +522,10 @@ class LafManagerImpl(private val coroutineScope: CoroutineScope) : LafManager(),
         return HIGH_CONTRAST_THEME_ID
       }
     }
+    /** Sherlock: Make "Light" theme as default
     return defaultDarkLaf.id
+    **/
+    return defaultLightLaf.id
   }
 
   /**


### PR DESCRIPTION
Before: 
<img width="954" alt="Screenshot 2025-05-13 at 17 26 45" src="https://github.com/user-attachments/assets/3c51dbeb-6f6e-40c6-b2d1-f6b831ff1869" />

After:
<img width="956" alt="Screenshot 2025-05-13 at 17 24 12" src="https://github.com/user-attachments/assets/138867df-271c-410b-a212-8d742ed4485c" />


Fixes #105 