### PR TITLE
Remove theme and colors from Settings Dialog > Appearance

### DIFF
--- a/platform/platform-impl/src/com/intellij/ide/ui/AppearanceConfigurable.kt
+++ b/platform/platform-impl/src/com/intellij/ide/ui/AppearanceConfigurable.kt
@@ -183,6 +183,7 @@ internal class AppearanceConfigurable : BoundSearchableConfigurable(message("tit
       val autodetectSupportedPredicate = ComponentPredicate.fromValue(lafManager.autodetectSupported)
       val syncThemeAndEditorSchemePredicate = autodetectSupportedPredicate.and(ComponentPredicate.fromObservableProperty(syncThemeProperty, disposable))
 
+      /** Sherlock: Remove theme and color from appearance in settings
       panel {
         row(message("combobox.look.and.feel")) {
           val lafComboBoxModelWrapper = LafComboBoxModelWrapper { lafManager.lafComboBoxModel }
@@ -236,6 +237,7 @@ internal class AppearanceConfigurable : BoundSearchableConfigurable(message("tit
           colorAndFontsOptions.disposeUIResources()
         }
       }
+      **/
 
       /** Sherlock: Remove Accessibility support
       group(message("title.accessibility")) {


### PR DESCRIPTION
Before:
<img width="904" alt="Screenshot 2025-05-13 at 17 29 05" src="https://github.com/user-attachments/assets/f3f25d42-f326-4338-9874-161b57039af6" />


After:
<img width="900" alt="Screenshot 2025-05-13 at 17 31 15" src="https://github.com/user-attachments/assets/7490e208-d6fa-404a-b6aa-c10e25505b69" />


Fixes #107 