### PR TITLE
Removes "Theme..." from settings drop-down under main toolbar

### DIFF
--- a/platform/platform-resources/src/idea/PlatformActions.xml
+++ b/platform/platform-resources/src/idea/PlatformActions.xml
@@ -1640,7 +1640,9 @@
       <reference id="ShowSettings"/>
       <reference id="WelcomeScreen.Plugins"/>
       <separator/>
+      <!--Sherlock: Remove theme from settings in main toolbar
       <reference id="ChangeLaf"/>
+      -->
       <reference id="ChangeKeymap"/>
       <reference id="ChangeView"/>
     </group>


### PR DESCRIPTION
Before:
<img width="239" alt="Screenshot 2025-05-13 at 16 19 46" src="https://github.com/user-attachments/assets/6ac7ef53-677b-4a10-8787-bf37abd4c35e" />


After: 
<img width="241" alt="Screenshot 2025-05-13 at 17 37 20" src="https://github.com/user-attachments/assets/12ac55ac-41d9-4aa8-a8cc-4bf650edd69f" />

Fixes #108 