### PR TITLE
Remove theme and color scheme from quick search

### DIFF
--- a/platform/platform-resources/src/idea/PlatformActions.xml
+++ b/platform/platform-resources/src/idea/PlatformActions.xml
@@ -1178,7 +1178,9 @@
     </group>
 
     <group id="ChangeScheme">
+      <!--Sherlock: Remove theme from quick search
       <action id="ChangeLaf" class="com.intellij.ide.actions.QuickChangeLookAndFeel"/>
+      -->
       <action id="ChangeColorScheme" class="com.intellij.ide.actions.QuickChangeColorSchemeAction"/>
       <action id="ChangeKeymap" class="com.intellij.ide.actions.QuickChangeKeymapAction"/>
       <action id="ChangeView" class="com.intellij.ide.actions.QuickChangeViewModeAction"/>


### PR DESCRIPTION
Before:
<img width="917" alt="Screenshot 2025-05-13 at 17 44 02" src="https://github.com/user-attachments/assets/4ca37118-fa6b-4be5-8cd9-1ddad85096b6" />

After:
<img width="882" alt="Screenshot 2025-05-13 at 17 45 03" src="https://github.com/user-attachments/assets/a92a278f-0241-4e30-806d-7e3592172d54" />

Fixes #112 