### PR TITLE
Remove "Change theme" option from Settings > Color Scheme

### DIFF
--- a/platform/platform-impl/src/com/intellij/application/options/colors/SchemesPanel.java
+++ b/platform/platform-impl/src/com/intellij/application/options/colors/SchemesPanel.java
@@ -47,6 +47,7 @@ public class SchemesPanel extends SimpleSchemesPanel<EditorColorsScheme> {
     return myListLoaded;
   }
 
+  /** Sherlock: Remove Change Theme Help option from color scheme under settings
   @Override
   protected ActionLink createActionLink() {
     String text;
@@ -65,6 +66,7 @@ public class SchemesPanel extends SimpleSchemesPanel<EditorColorsScheme> {
       }
     });
   }
+  **/
 
   @Override
   protected @Nullable JLabel createActionLinkCommentLabel() {
@@ -78,11 +80,14 @@ public class SchemesPanel extends SimpleSchemesPanel<EditorColorsScheme> {
     }
   }
 
+  /** Sherlock: Remove Change Theme Help option from color scheme under settings
   @Nls
   @Override
   protected String getContextHelpLabelText() {
     return ApplicationBundle.message("editbox.scheme.context.help.label");
   }
+  **/
+
 
   void resetSchemesCombo(final Object source) {
     if (this != source) {


### PR DESCRIPTION
Removes "Change IDE Theme..." option as it now redirects to nothing (after #111 got merged). Also removes the helper text next to it. 

Before:
![Screenshot 2025-05-14 at 2 10 33 pm](https://github.com/user-attachments/assets/f2bdc383-55cc-4aa0-a342-bd2bab46bcb4)

After:
![Screenshot 2025-05-14 at 2 47 17 pm](https://github.com/user-attachments/assets/9692334d-ba26-4b0c-95cb-e56e6ec08dd5)


Tests: Manual