### PR TITLE
Bump the version in SherlockPlatformApplicationInfo.xml to the next pre-release version

### DIFF
--- a/sherlock-branding/resources/idea/SherlockPlatformApplicationInfo.xml
+++ b/sherlock-branding/resources/idea/SherlockPlatformApplicationInfo.xml
@@ -2,7 +2,7 @@
   <!-- Original version of IntelliJ Platform was: -->
   <!-- <version major="2024" minor="2.1"/>  -->
   <!-- The following is the Sherlock platform version: -->
-  <version major="1" minor="0" patch="1"/>
+  <version major="1" minor="0" patch="2"/>
   <company name="Google" url="http://developer.android.com"/>
   <build number="IC-__BUILD__" date="__BUILD_DATE__" majorReleaseDate="20240806" />
   <logo url="/sherlock_logo.png"/>


### PR DESCRIPTION
As per the last point in [README.md](https://github.com/android-graphics/sherlock-platform?tab=readme-ov-file#creating-a-new-release-for-sherlock-platform), `main` should now point to the next release version - v1.0.2