### PR TITLE
Remove Structure tool window from Platform

### DIFF
--- a/platform/platform-resources/src/META-INF/LangExtensions.xml
+++ b/platform/platform-resources/src/META-INF/LangExtensions.xml
@@ -1049,8 +1049,10 @@
     <toolWindow id="Project" anchor="left" icon="AllIcons.Toolwindows.ToolWindowProject"
                 factoryClass="com.intellij.ide.projectView.impl.ProjectViewToolWindowFactory"/>
 
+    <!--Sherlock: Remove Structure tool window
     <toolWindow id="Structure" anchor="left" icon="AllIcons.Toolwindows.ToolWindowStructure" secondary="true"
                 factoryClass="com.intellij.ide.structureView.impl.StructureViewToolWindowFactory"/>
+    -->
     <!--Sherlock: Remove bookmarks tool window
     <toolWindow id="Bookmarks" anchor="left" icon="AllIcons.Toolwindows.ToolWindowBookmarks" secondary="true"
                 factoryClass="com.intellij.ide.bookmark.ui.BookmarksViewFactory" order="after Structure"/>


### PR DESCRIPTION
Removes Structure from Side Toolbar as well as View > Tools Windows

Before: 
<img width="146" alt="Screenshot 2025-06-23 at 2 44 55 PM" src="https://github.com/user-attachments/assets/63ed9a23-5e31-4b4e-aa79-d32039b6d0f1" />
<img width="478" alt="Screenshot 2025-06-23 at 2 45 08 PM" src="https://github.com/user-attachments/assets/679e7bb7-ee1a-4dd4-95f3-1f8d262d1df3" />


After:
<img width="274" alt="Screenshot 2025-06-23 at 2 48 25 PM" src="https://github.com/user-attachments/assets/744cdc10-b7f7-4554-8dfd-e636f2db6696" />

<img width="553" alt="Screenshot 2025-06-23 at 2 45 29 PM" src="https://github.com/user-attachments/assets/3abba9cf-12bb-49eb-a79b-8de34be2ab65" />

Test:
Manual
