### PR TITLE
Rename "capture" to "trace" in welcome page and empty project background

### DIFF
--- a/platform/platform-api/resources/messages/IdeBundle.properties
+++ b/platform/platform-api/resources/messages/IdeBundle.properties
@@ -1429,7 +1429,7 @@ empty.text.go.to.file=Go to File
 empty.text.project.view=Project View
 empty.text.drop.files.to.open=Drop files here to open them
 # Sherlock: Advertise mew capture functionality on empty project page
-empty.text.new.capture=Click on the New Capture button on the toolbar to take a capture
+empty.text.new.capture=Click on the Record Trace button on the toolbar to start recording a trace
 scratches.and.consoles=Scratches and Consoles
 action.DumbAware.BuildView.text.stop=BuildView
 action.DumbAware.CopyrightProfilesPanel.description.stop=Stop

--- a/platform/platform-api/resources/messages/IdeBundle.properties
+++ b/platform/platform-api/resources/messages/IdeBundle.properties
@@ -2235,8 +2235,8 @@ welcome.screen.drop.files.to.open.text=Drop files here to open
 # Sherlock: Modified UI strings to specify capture
 # welcome.screen.empty.projects.create.comment= Create a new project to start from scratch.
 # welcome.screen.empty.projects.open.comment=Open existing project from disk or version control.
-welcome.screen.empty.projects.create.comment=Create a new project to start your first capture.
-welcome.screen.empty.projects.open.comment=Open an existing project or a capture.
+welcome.screen.empty.projects.create.comment=Create a new project to start recording your first trace.
+welcome.screen.empty.projects.open.comment=Open an existing project or a trace.
 
 
 welcome.screen.more.actions.link.text=More Actions


### PR DESCRIPTION
Context: https://github.com/android-graphics/sherlock/issues/965

After this change:

<img width="1612" height="1308" alt="image" src="https://github.com/user-attachments/assets/96b6165d-5213-4670-ab3e-f76bbbc8b826" />

<img width="2270" height="766" alt="image" src="https://github.com/user-attachments/assets/e8284d8c-f5ed-4027-b262-6ea7c2e67942" />

