### PR TITLE
Hide excluded files by default

### DIFF
--- a/platform/lang-impl/src/com/intellij/ide/projectView/ProjectViewSettings.java
+++ b/platform/lang-impl/src/com/intellij/ide/projectView/ProjectViewSettings.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.Nullable;
 
 public interface ProjectViewSettings extends ViewSettings {
   default boolean isShowExcludedFiles() {
-    return true;
+    return false;
   }
 
   default boolean isShowVisibilityIcons() {
@@ -39,7 +39,7 @@ public interface ProjectViewSettings extends ViewSettings {
 
     public Immutable(ProjectViewSettings settings) {
       super(settings);
-      myShowExcludedFiles = settings == null || settings.isShowExcludedFiles();
+      myShowExcludedFiles = settings != null && settings.isShowExcludedFiles();
       myShowVisibilityIcons = settings != null && settings.isShowVisibilityIcons();
       myUseFileNestingRules = settings == null || settings.isUseFileNestingRules();
     }

--- a/platform/lang-impl/src/com/intellij/ide/projectView/impl/ProjectViewSharedSettings.kt
+++ b/platform/lang-impl/src/com/intellij/ide/projectView/impl/ProjectViewSharedSettings.kt
@@ -22,7 +22,7 @@ class ProjectViewSharedSettings : PersistentStateComponent<ProjectViewSharedSett
   var sortKey: NodeSortKey = ProjectViewSettings.Immutable.DEFAULT.sortKey
   var showModules: Boolean = true
   var flattenModules: Boolean = false
-  var showExcludedFiles: Boolean = true
+  var showExcludedFiles: Boolean = false
   var showVisibilityIcons: Boolean = false
   var showLibraryContents: Boolean = true
   var showScratchesAndConsoles: Boolean = true

--- a/platform/util/resources/misc/registry.properties
+++ b/platform/util/resources/misc/registry.properties
@@ -155,7 +155,7 @@ ide.editor.tabs.fadeout.width.description=Size of semi-transparent fadeout area
 ide.editor.tabs.visible.in.presentation.mode=false
 ide.editor.tabs.visible.in.presentation.mode.description=Keep editor tabs visible even if Presentation mode is ON
 
-ide.hide.excluded.files=false
+ide.hide.excluded.files=true
 ide.hide.excluded.files.restartRequired=true
 ide.hide.excluded.files.description=Do not show excluded files in Project View and exclude them from VCS
 


### PR DESCRIPTION
All files that start with . are excluded files, which will no longer be displayed in the project view.

When testing this in Sherlock Platform, I had to delete the $root/config directory, otherwise it always picked up the project-default.xml file there which contained the old defaults.

Tested by:
- Delete config dir, invalidate all caches
- Create new project
- (Cmd|Ctrl)+S to save project
- Verify that .idea folder is not shown in project view