### PR TITLE
Include Jewel Markdown modules

### DIFF
--- a/sherlock-branding/resources/META-INF/SherlockPlatformPlugin.xml
+++ b/sherlock-branding/resources/META-INF/SherlockPlatformPlugin.xml
@@ -15,6 +15,8 @@
     <module name="intellij.platform.jewel.foundation"/>
     <module name="intellij.platform.jewel.ui"/>
     <module name="intellij.platform.jewel.ideLafBridge"/>
+    <module name="intellij.platform.jewel.markdown.core"/>
+    <module name="intellij.platform.jewel.markdown.ideLafBridgeStyling"/>
   </content>
 
 </idea-plugin>


### PR DESCRIPTION
These modules are required as transitive dependency to build sherlock-plugin using bazel. 

Fixes #173 