### PR TITLE
Add more jewel.markdown modules

### DIFF
--- a/sherlock-branding/resources/META-INF/SherlockPlatformPlugin.xml
+++ b/sherlock-branding/resources/META-INF/SherlockPlatformPlugin.xml
@@ -17,6 +17,10 @@
     <!-- Jewel-based Markdown modules are required for bazel build -->
     <module name="intellij.platform.jewel.markdown.core"/>
     <module name="intellij.platform.jewel.markdown.ideLafBridgeStyling"/>
+    <module name="intellij.platform.jewel.markdown.extensions.gfmAlerts"/>
+    <module name="intellij.platform.jewel.markdown.extensions.gfmStrikethrough"/>
+    <module name="intellij.platform.jewel.markdown.extensions.gfmTables"/>
+    <module name="intellij.platform.jewel.markdown.extensions.autolink"/>
   </content>
 
 </idea-plugin>


### PR DESCRIPTION
When we added `intellij.platform.jewel.markdown.ideLafBridgeStyling` as a dependency to Sherlock (in https://github.com/android-graphics/sherlock-platform/pull/175), it started failing at runtime with this error:

<img width="512" height="428" alt="image" src="https://github.com/user-attachments/assets/c135d413-7e4f-45fc-b163-2e7513326951" />


This is because `intellij.platform.jewel.markdown.ideLafBridgeStyling` has an xml file with these transitive dependencies:

https://github.com/android-graphics/sherlock-platform/blob/f7ffc37dbe699dc6ef14fea01fd8656ed786680f/platform/jewel/markdown/ide-laf-bridge-styling/src/main/resources/intellij.platform.jewel.markdown.ideLafBridgeStyling.xml#L7-L8


So, we need these `markdown.extensions.*` to also be included in our Sherlock platform.


Test:
1. Run build_sherlock_platform,.sh
2. Copy output zip artifact into sherlock repo out/prebuilts/ and extract.
3. Run `./gradlew runIde`
4. Verify that Sherlock doesn't have runtime errors.
