### PR TITLE
[Revert] Don't build for mac-x64 platform (#11)

### DIFF
--- a/build_sherlock_platform.sh
+++ b/build_sherlock_platform.sh
@@ -13,7 +13,7 @@ BUILD_PROPERTIES=(
   "-Dbuild.number=${AS_BUILD_NUMBER}"
   "-Dintellij.build.dev.mode=false"
   "-Dcompile.parallel=true"
-  "-Dintellij.build.skip.build.steps=repair_utility_bundle_step,mac_dmg,mac_sign,mac_sit,windows_exe_installer,linux aarch64,windows aarch64,mac x64"
+  "-Dintellij.build.skip.build.steps=repair_utility_bundle_step,mac_dmg,mac_sign,mac_sit,windows_exe_installer,linux aarch64,windows aarch64"
   "-Dintellij.build.incremental.compilation=true"
   "-Dintellij.build.incremental.compilation.fallback.rebuild=false"
 )


### PR DESCRIPTION
`intellij_platform` bazel rule requires an darwin-x86_x64 version to exist. So, we'll generate one but won't ship it. 